### PR TITLE
feat(alphabet): no validate if _alphabet_ is ORIGINAL

### DIFF
--- a/lib/alphabet.js
+++ b/lib/alphabet.js
@@ -29,12 +29,14 @@ function setCharacters(_alphabet_) {
         throw new Error('Custom alphabet for shortid must be ' + ORIGINAL.length + ' unique characters. You submitted ' + _alphabet_.length + ' characters: ' + _alphabet_);
     }
 
-    var unique = _alphabet_.split('').filter(function(item, ind, arr){
-       return ind !== arr.lastIndexOf(item);
-    });
+    if (_alphabet_ !== ORIGINAL) {
+        var unique = _alphabet_.split('').filter(function(item, ind, arr){
+            return ind !== arr.lastIndexOf(item);
+         });
 
-    if (unique.length) {
-        throw new Error('Custom alphabet for shortid must be ' + ORIGINAL.length + ' unique characters. These characters were not unique: ' + unique.join(', '));
+         if (unique.length) {
+             throw new Error('Custom alphabet for shortid must be ' + ORIGINAL.length + ' unique characters. These characters were not unique: ' + unique.join(', '));
+         }
     }
 
     alphabet = _alphabet_;


### PR DESCRIPTION
If the provided `_alphabet_` is equal to the statically-defined `ORIGINAL`, we don't need to validate for uniqueness. This has 2 effects:

1. `Array.prototype.filter` is not used when not using custom alphabets, which increases compatibility with browsers/libraries that may not have that method/define it in an unconventional way (e.g. Prototype 1.6)
2. Slight performance increase when setting the alphabet to the default.