### PR TITLE
feat(alphabet): avoid Array.prototype.filter

### DIFF
--- a/lib/alphabet.js
+++ b/lib/alphabet.js
@@ -29,9 +29,14 @@ function setCharacters(_alphabet_) {
         throw new Error('Custom alphabet for shortid must be ' + ORIGINAL.length + ' unique characters. You submitted ' + _alphabet_.length + ' characters: ' + _alphabet_);
     }
 
-    var unique = _alphabet_.split('').filter(function(item, ind, arr){
-       return ind !== arr.lastIndexOf(item);
-    });
+    // For compatibility with Prototype < 1.7, avoid Array.prototype.filter
+    var chars = _alphabet_.split('');
+    var unique = [];
+    for (var i = 0; i < chars.length; i++) {
+        if (i !== chars.lastIndexOf(chars[i])) {
+            unique.push(chars[i]);
+        }
+    }
 
     if (unique.length) {
         throw new Error('Custom alphabet for shortid must be ' + ORIGINAL.length + ' unique characters. These characters were not unique: ' + unique.join(', '));


### PR DESCRIPTION
Use a `for` loop instead of `Array.prototype.filter` for better compatibility with browsers/libraries that may not have that method, or may define it in an incompatible way (e.g. [IE8](http://caniuse.com/#feat=es5), [Prototype < 1.7](http://prototypejs.org/doc/1.6.0/enumerable/findAll.html)).

Tested in Chrome, IE9. I couldn't get the tests to run in IE8, but I think that was an issue with the tests, since (1) I didn't change anything that would _decrease_ browser support, (2) this is an issue in master as well, and (3) the error was in an `assert` library function itself, and it looks like `chai` might not support IE8.

Fixes https://github.com/dylang/shortid/issues/103